### PR TITLE
Update execution type to AZURE and modify endpoint name in deployment config

### DIFF
--- a/llmops/config.py
+++ b/llmops/config.py
@@ -8,4 +8,4 @@ It contains the following configuration:
   Valid values: LOCAL, AZURE
 """
 
-EXECUTION_TYPE = "LOCAL"
+EXECUTION_TYPE = "AZURE"

--- a/named_entity_recognition/configs/deployment_config.json
+++ b/named_entity_recognition/configs/deployment_config.json
@@ -3,7 +3,7 @@
         {
             "ENV_NAME": "dev",
             "TEST_FILE_PATH": "sample-request.json",
-            "ENDPOINT_NAME": "",
+            "ENDPOINT_NAME": "named_entity_recognition_endpoint",
             "ENDPOINT_DESC": "An online endpoint serving a flow for named entity flow",
             "DEPLOYMENT_DESC": "prompt flow deployment",
             "PRIOR_DEPLOYMENT_NAME": "",

--- a/named_entity_recognition/sample-request.json
+++ b/named_entity_recognition/sample-request.json
@@ -1,3 +1,3 @@
 {
-    "text": "Tri is a data scientist at Auto Dataset, and his wife is a finance manager in the same company.", "entity_type": "job title"
+    "text": "Tri is a technical architect at Auto Dataset, and his wife is a finance manager in the same company.", "entity_type": "job title"
 }


### PR DESCRIPTION
Change the execution type to AZURE and set a specific endpoint name in the deployment configuration. Additionally, update a sample text to reflect a new job title.